### PR TITLE
Fix for issue #20 : Dockerfile keyword missing

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -62,7 +62,7 @@ RUN yum -y -q install zabbix-agent  \
               zabbix22-dbfiles-mysql
 
 # YUM Cleanup
-yum clean all && rm -rf /tmp/*
+RUN yum clean all && rm -rf /tmp/*
 
 # MySQL
 COPY ./mysql/my.cnf /etc/mysql/conf.d/my.cnf


### PR DESCRIPTION
The "RUN" imperative was missing from the Docker file henceforth the docker build phase would fail.
Added it and testrun, seems to work ok. 
(Build with docker build and then run , zabbix seems running fine)